### PR TITLE
Dislike memory

### DIFF
--- a/resources/material_kit/src/views/Components/Sections/SectionHomeTabs.jsx
+++ b/resources/material_kit/src/views/Components/Sections/SectionHomeTabs.jsx
@@ -66,36 +66,6 @@ class SectionTabs extends React.Component {
       });
   }
 
-  handleDislike(id) {
-    var userToken = localStorage.getItem("token");
-    var _this = this;
-    console.log(userToken);
-    fetch(
-      "http://ec2-18-234-162-48.compute-1.amazonaws.com:8000/post/dislike/".concat(
-        id
-      ).concat(
-        "/"
-      ),
-      {
-        mode: "cors",
-        headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET",
-          "Access-Control-Allow-Headers": "Content-Type",
-          "Authorization": "JWT " + userToken
-        },
-        method: "GET"
-      })
-      .then(response => response.json())
-      .then(function(data) {
-        console.log(data);
-      })
-      .catch(function(error) {
-        console.log("There has been a problem with your fetch operation: " + error.message);
-      });
-  }
-
   componentDidMount() {
     var userToken = localStorage.getItem("token");
     var _this = this;
@@ -183,15 +153,6 @@ class SectionTabs extends React.Component {
                                   }
                                 >
                                   Like
-                                </Button>
-                                <br />
-                                <Button
-                                  onClick={() =>
-                                    this.handleDislike(prop.id)
-                                  }
-                                  color= "danger"
-                                >
-                                  Dislike
                                 </Button>
                               </div>
                             )

--- a/resources/material_kit/src/views/Components/Sections/SectionHomeTabs.jsx
+++ b/resources/material_kit/src/views/Components/Sections/SectionHomeTabs.jsx
@@ -66,6 +66,36 @@ class SectionTabs extends React.Component {
       });
   }
 
+  handleDislike(id) {
+    var userToken = localStorage.getItem("token");
+    var _this = this;
+    console.log(userToken);
+    fetch(
+      "http://ec2-18-234-162-48.compute-1.amazonaws.com:8000/post/dislike/".concat(
+        id
+      ).concat(
+        "/"
+      ),
+      {
+        mode: "cors",
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Authorization": "JWT " + userToken
+        },
+        method: "GET"
+      })
+      .then(response => response.json())
+      .then(function(data) {
+        console.log(data);
+      })
+      .catch(function(error) {
+        console.log("There has been a problem with your fetch operation: " + error.message);
+      });
+  }
+
   componentDidMount() {
     var userToken = localStorage.getItem("token");
     var _this = this;
@@ -153,6 +183,15 @@ class SectionTabs extends React.Component {
                                   }
                                 >
                                   Like
+                                </Button>
+                                <br />
+                                <Button
+                                  onClick={() =>
+                                    this.handleDislike(prop.id)
+                                  }
+                                  color= "danger"
+                                >
+                                  Dislike
                                 </Button>
                               </div>
                             )


### PR DESCRIPTION
Dislike button is implemented. Resolves #169.

Please note that dislike and like buttons are separate.

Testing the functionality: At /home-page, there is "LIKE" tab on each memory. After clicking on that tab, dislike button appears (red) and clicking on the this button dislikes the memory. When dislike button is clicked, the ID of the user who liked this memory is discarded from `liked_users`. If the ID of this user is not in `liked_users`, then nothing changes in `liked_users`.
<img width="828" alt="screenshot 2018-12-25 at 19 43 04" src="https://user-images.githubusercontent.com/14012497/50424895-51ee0b80-087d-11e9-9209-94eef1c384c4.png">
